### PR TITLE
Ignore root folder in album naming (#1)

### DIFF
--- a/src/immich_migration/migration.py
+++ b/src/immich_migration/migration.py
@@ -99,12 +99,9 @@ class PhotoMigration:
             album_name = " - ".join(album_path) if album_path else directory.name
             self._upload_to_album(media_files, album_name)
 
-        # Process subdirectories
+        # Process subdirectories, ignoring the root folder in album naming
         for subdir, name in subdirs:
             new_parent_path = parent_path.copy()
-            if not new_parent_path:
-                # If we're at the root, use the root directory name
-                new_parent_path.append(directory.name)
             new_parent_path.append(name)
             self._process_directory(subdir, new_parent_path)
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from immich_migration.config import Config
 from immich_migration.migration import PhotoMigration
+from pathlib import Path
+import tempfile
 
 
 class TestMigration(unittest.TestCase):
@@ -42,6 +44,34 @@ class TestMigration(unittest.TestCase):
             album_id = migrator._get_or_create_album("Root - Subfolder")
             self.assertEqual(album_id, "test-album-id")
             mock_client.create_album.assert_called_with("Root - Subfolder")
+    
+    @patch("immich_migration.client.ImmichClient.create_album")
+    def test_ignore_root_folder_in_album_naming(self, mock_create):
+        """Ensure albums are named without the root directory prefix via create_album calls."""
+        # Mock create_album to return a dummy with an id
+        mock_create.return_value.id = "dummy-id"
+        # Build a temporary directory structure
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            # Folder A and its subfolder
+            folder_a = root / "FolderA"
+            folder_a.mkdir()
+            (folder_a / "img1.jpg").write_text("data")
+            sub_a = folder_a / "FolderA1"
+            sub_a.mkdir()
+            (sub_a / "img2.jpg").write_text("data")
+            # Folder B
+            folder_b = root / "FolderB"
+            folder_b.mkdir()
+            (folder_b / "img3.jpg").write_text("data")
+            # Execute migration
+            migrator = PhotoMigration(self.config)
+            migrator.migrate(root)
+        # Collect album names used in create_album calls
+        called_album_names = [call.args[-1] for call in mock_create.call_args_list]
+        # Should only include the subfolders without the root prefix
+        expected = {"FolderA", "FolderA - FolderA1", "FolderB"}
+        self.assertEqual(set(called_album_names), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR modifies the migration logic to no longer include the root directory name in generated album names, fixing issue #1.

- Removed root folder prefix in _process_directory
- Added tests to validate behavior